### PR TITLE
rephrase grocy URL pattern error message

### DIFF
--- a/src/app/features/settings/grocy-api/grocy-api.component.html
+++ b/src/app/features/settings/grocy-api/grocy-api.component.html
@@ -3,7 +3,7 @@
       [control]="formControl('url')"
       label="Grocy URL"
       >
-      <ns-form-error-text validator="pattern" message="Expected to be http(s)://somehost/api"></ns-form-error-text>
+      <ns-form-error-text validator="pattern" message="Please use the format http[s]://[domain or IP][:port]/api"></ns-form-error-text>
     </ns-text-input>
     <ns-text-input
       [control]="formControl('apiKey')"


### PR DESCRIPTION
This should hopefully help prevent future confusion such as that from #104 by providing a recognizable pattern-like string similar to those found in the manpages to indicate the general format of the URL that Pantry Party is expecting and show where certain pieces (like port number or the "s" in https) are optional.

By specifiying the format this way, this should suggest to the (presumably more tech savvy than most) user base that the `http://` or `https://` part is required (IMO this should automatically be added if left off, but that's a different feature) and that both domain names and IP/Port combinations are acceptable.


One drawback to using square brachets to indicate "optional" and also separate a piece of text that needs to be replaced is that it inadvertently suggests that the hostname/IP is optional, which it is clearly not, maybe there's a better formatting mechanism to properly convey this?