### PR TITLE
scan-selector: enable DATA_MATRIX

### DIFF
--- a/src/app/scan-selector/scan-selector.component.ts
+++ b/src/app/scan-selector/scan-selector.component.ts
@@ -16,7 +16,7 @@ export class ScanSelectorComponent {
 
   enableExternalScanner = false;
   scannerSettings: ScanOptions = {
-      formats: "QR_CODE, EAN_13, UPC_A, UPC_E",
+      formats: "QR_CODE, EAN_13, UPC_A, UPC_E, DATA_MATRIX",
       beepOnScan: true,
       reportDuplicates: true,
       preferFrontCamera: false,


### PR DESCRIPTION
The 2D barcodes from Grocy are data matrix.

I haven't built and tested this: I don't know how :(. But I'd love to know how so that I can!